### PR TITLE
feat: adding runs if method to flow class

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ With a fluent API, you can easily chain steps, incorporate conditional logic, an
 
 ## Features
 
-- **Fluent API**: Easily chain workflow steps using methods like `run()`, `branch()`, and `chain()`.
+- **Fluent API**: Easily chain workflow steps using methods like `run()`, `branch()`, `chain()`, and the new `runIf()`.
 - **Conditional Branches**: Integrate custom conditions using your own implementations of `FlowCondition`.
 - **Testable & Modular**: Each step is isolated, making it a breeze to unit test and maintain.
 
@@ -212,6 +212,25 @@ class IsVIPUser implements FlowCondition
 }
 ```
 
+### Automatic Step Skipping
+
+Instead of embedding skip logic within each step, you can use the `runIf()` method to automatically skip steps based on a condition. This method takes a callable condition and an action. If the condition evaluates to true, the step executes; otherwise, it is skipped.
+
+```php
+use JustSteveKing\Flows\Flow;
+use App\Flows\Steps\StepTwo;
+use App\Flows\Steps\StepFour;
+
+$shouldRunStepFour = function ($payload): bool {
+    return !empty($payload['processStepFour']);
+};
+
+$result = Flow::start()
+    ->run(action: StepTwo::class)
+    ->runIf($shouldRunStepFour, StepFour::class)
+    ->execute(payload: ['processStepFour' => false, 'data' => 'test']);
+```
+
 ### Putting It All Together
 
 When defining your workflows, you can mix and match steps and conditions seamlessly. Use `run()` or `chain()` for your steps and `branch()` for conditionally running sub-flows. This keeps your business logic clean and flexible.
@@ -254,7 +273,7 @@ By following these interfaces, every step in your workflow will have a consisten
 
 ```mermaid
 flowchart TD
-    A[Flow] --> B[run Steps]
+    A[Flow::start] --> B[run Steps]
     B --> C[branch Conditions]
     C --> D[chain Steps]
     D --> E[execute Payload]

--- a/src/Flow.php
+++ b/src/Flow.php
@@ -66,8 +66,8 @@ final class Flow
      */
     public function runIf(callable $condition, string $action): self
     {
-        $this->steps[] = static function ($payload, $next) use ($condition, $action) {
-            if (!$condition($payload)) {
+        $this->steps[] = static function (mixed $payload, Closure $next) use ($condition, $action) {
+            if ( ! $condition($payload)) {
                 return $next($payload);
             }
             return resolve($action)->handle($payload, $next);

--- a/src/Flow.php
+++ b/src/Flow.php
@@ -58,6 +58,25 @@ final class Flow
     }
 
     /**
+     * Add a step that will only run if the condition is met.
+     *
+     * @param callable $condition A callable that receives the payload and returns a boolean.
+     * @param class-string<FlowStep> $action
+     * @return $this
+     */
+    public function runIf(callable $condition, string $action): self
+    {
+        $this->steps[] = static function ($payload, $next) use ($condition, $action) {
+            if (!$condition($payload)) {
+                return $next($payload);
+            }
+            return resolve($action)->handle($payload, $next);
+        };
+
+        return $this;
+    }
+
+    /**
      * @param class-string<FlowStep> $action
      * @return $this
      */

--- a/tests/FlowTest.php
+++ b/tests/FlowTest.php
@@ -123,9 +123,7 @@ final class FlowTest extends PackageTestCase
     #[Test]
     public function runIfStepIsExecutedWhenConditionIsTrue(): void
     {
-        $condition = function ($payload): bool {
-            return true;
-        };
+        $condition = fn($payload): bool => true;
 
         $flow = Flow::start()->runIf($condition, DummyStep::class);
         $result = $flow->execute('bar');
@@ -136,9 +134,7 @@ final class FlowTest extends PackageTestCase
     #[Test]
     public function runIfStepIsSkippedWhenConditionIsFalse(): void
     {
-        $condition = function ($payload): bool {
-            return false;
-        };
+        $condition = fn($payload): bool => false;
 
         $flow = Flow::start()->runIf($condition, DummyStep::class);
         $result = $flow->execute('bar');

--- a/tests/FlowTest.php
+++ b/tests/FlowTest.php
@@ -119,4 +119,30 @@ final class FlowTest extends PackageTestCase
 
         $this->assertFalse(isset($result['modified']));
     }
+
+    #[Test]
+    public function runIfStepIsExecutedWhenConditionIsTrue(): void
+    {
+        $condition = function ($payload): bool {
+            return true;
+        };
+
+        $flow = Flow::start()->runIf($condition, DummyStep::class);
+        $result = $flow->execute('bar');
+
+        $this->assertEquals('bar foo', $result);
+    }
+
+    #[Test]
+    public function runIfStepIsSkippedWhenConditionIsFalse(): void
+    {
+        $condition = function ($payload): bool {
+            return false;
+        };
+
+        $flow = Flow::start()->runIf($condition, DummyStep::class);
+        $result = $flow->execute('bar');
+
+        $this->assertEquals('bar', $result);
+    }
 }

--- a/tests/FlowTest.php
+++ b/tests/FlowTest.php
@@ -12,6 +12,7 @@ use JustSteveKing\Flows\Tests\Doubles\ExceptionStep;
 use JustSteveKing\Flows\Tests\Doubles\IsFalse;
 use JustSteveKing\Flows\Tests\Doubles\IsTrue;
 use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
 
 final class FlowTest extends PackageTestCase
 {
@@ -140,5 +141,18 @@ final class FlowTest extends PackageTestCase
         $result = $flow->execute('bar');
 
         $this->assertEquals('bar', $result);
+    }
+
+    #[Test]
+    public function runIfThrowsRuntimeExceptionWhenActionCannotBeResolved(): void
+    {
+        // Condition returns true, so the step will be attempted.
+        $condition = fn($payload): bool => true;
+        $invalidAction = 'NonExistent\Step';
+
+        $flow = Flow::start()->runIf($condition, $invalidAction);
+
+        $this->expectException(RuntimeException::class);
+        $flow->execute('bar');
     }
 }


### PR DESCRIPTION
Instead of creating a branch, and starting another sub-workflow, you can now use the `runIf` method to only run a step if a condition passes, keeping it cleaner and simpler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to conditionally execute workflow steps based on specified conditions, enhancing flexibility in task chaining.

- **Documentation**
  - Updated the README with examples and diagrams to illustrate the new method for conditional execution and improved workflow configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->