### PR TITLE
feat: catching exceptions within the flow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,46 @@ $result = Flow::start()
     ->execute(payload: ['processStepFour' => false, 'data' => 'test']);
 ```
 
+### Catching Exceptions
+
+The `catch` method allows you to handle exceptions that occur during the flow execution. You can add error handling logic that will intercept any exceptions thrown by previous steps in the flow.
+
+```php
+use JustSteveKing\Flows\Flow;
+
+$flow = Flow::start()->run(
+    action: RiskyOperation::class,
+)->catch(
+    errorHandler: function (Throwable $e, mixed $payload) {
+        // Handle the exception
+        return $payload; // or return modified payload
+    },
+);
+```
+
+Example with Error Logging:
+
+```php
+use JustSteveKing\Flows\Flow;
+use Illuminate\Support\Facades\Log;
+
+$flow = Flow::start()
+    ->run(CreateUser::class)
+    ->catch(function (Throwable $e, array $payload) {
+        Log::error('User creation failed', [
+            'error' => $e->getMessage(),
+            'payload' => $payload,
+        ]);
+        
+        return array_merge($payload, ['error' => 'Failed to create user']);
+    });
+
+$result = $flow->execute([
+    'email' => 'user@example.com',
+    'name' => 'Test User',
+]);
+```
+
 ### Putting It All Together
 
 When defining your workflows, you can mix and match steps and conditions seamlessly. Use `run()` or `chain()` for your steps and `branch()` for conditionally running sub-flows. This keeps your business logic clean and flexible.

--- a/src/Flow.php
+++ b/src/Flow.php
@@ -103,6 +103,19 @@ final class Flow
         return $this;
     }
 
+    public function catch(callable $errorHandler): Flow
+    {
+        $this->steps[] = static function (mixed $payload, Closure $next) use ($errorHandler) {
+            try {
+                return $next($payload);
+            } catch (Throwable $e) {
+                return $errorHandler($e, $payload);
+            }
+        };
+
+        return $this;
+    }
+
     /**
      * @param mixed $payload
      * @return mixed

--- a/tests/FlowTest.php
+++ b/tests/FlowTest.php
@@ -261,7 +261,7 @@ final class FlowTest extends PackageTestCase
     public function it_propagates_exceptions_without_catch_handler(): void
     {
         $flow = Flow::start()
-            ->run(function ($payload) {
+            ->run(function ($payload): void {
                 throw new RuntimeException('Unhandled error');
             });
 

--- a/tests/FlowTest.php
+++ b/tests/FlowTest.php
@@ -13,6 +13,7 @@ use JustSteveKing\Flows\Tests\Doubles\IsFalse;
 use JustSteveKing\Flows\Tests\Doubles\IsTrue;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
+use Throwable;
 
 final class FlowTest extends PackageTestCase
 {
@@ -154,5 +155,119 @@ final class FlowTest extends PackageTestCase
 
         $this->expectException(RuntimeException::class);
         $flow->execute('bar');
+    }
+
+    #[Test]
+    public function catchHandlerInterceptsExceptions(): void
+    {
+        $this->expectException(Exception::class);
+
+        $flow = Flow::start()
+            ->run(ExceptionStep::class)
+            ->catch(fn(Throwable $e, string $payload) => $payload . ' caught');
+
+        $result = $flow->execute('test');
+
+        $this->assertEquals('test caught', $result);
+    }
+
+    #[Test]
+    public function catchHandlerIsSkippedWhenNoExceptionOccurs(): void
+    {
+        $flow = Flow::start()
+            ->run(fn($payload, $next) => $next($payload . ' success'))
+            ->catch(fn(Throwable $e, string $payload) => $payload . ' caught');
+
+        $result = $flow->execute('test');
+
+        $this->assertEquals('test success', $result);
+    }
+
+    #[Test]
+    public function itCatchesSpecificExceptions(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $flow = Flow::start()
+            ->run(function ($payload): void {
+                throw new RuntimeException('Specific error');
+            })
+            ->catch(fn(RuntimeException $e, $payload) => 'caught runtime exception');
+
+        $result = $flow->execute('test');
+
+        $this->assertEquals('caught runtime exception', $result);
+    }
+
+    #[Test]
+    public function itCanModifyPayloadInCatchBlock(): void
+    {
+        $this->expectException(Exception::class);
+        $flow = Flow::start()
+            ->run(function ($payload): void {
+                throw new Exception('Failed operation');
+            })
+            ->catch(fn(Throwable $e, array $payload) => array_merge($payload, [
+                'error' => $e->getMessage(),
+                'status' => 'failed',
+            ]));
+
+        $result = $flow->execute(['initial' => 'data']);
+
+        $this->assertEquals([
+            'initial' => 'data',
+            'error' => 'Failed operation',
+            'status' => 'failed',
+        ], $result);
+    }
+
+    #[Test]
+    public function itPropagatesUnhandledExceptions(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unhandled error');
+
+        $flow = Flow::start()
+            ->run(function ($payload): void {
+                throw new RuntimeException('Unhandled error');
+            });
+
+        $flow->execute('test');
+    }
+
+    #[Test]
+    public function itPreservesExceptionChain(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $previousException = new Exception('Previous error');
+        $caught = null;
+
+        $flow = Flow::start()
+            ->run(function ($payload) use ($previousException): void {
+                throw new RuntimeException('Main error', 0, $previousException);
+            })
+            ->catch(function (Throwable $e) use (&$caught) {
+                $caught = $e;
+                return 'handled';
+            });
+
+        $flow->execute('test');
+
+        $this->assertInstanceOf(RuntimeException::class, $caught);
+        $this->assertInstanceOf(Exception::class, $caught->getPrevious());
+        $this->assertEquals('Previous error', $caught->getPrevious()->getMessage());
+    }
+
+    #[Test]
+    public function it_propagates_exceptions_without_catch_handler(): void
+    {
+        $flow = Flow::start()
+            ->run(function ($payload) {
+                throw new RuntimeException('Unhandled error');
+            });
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unhandled error');
+
+        $flow->execute('test');
     }
 }


### PR DESCRIPTION
This PR adds the `catch` method, which allows you to pass through a callable error handler for how you want to handle any exceptions that are thrown.