### PR TITLE
feat: adding debug method for easier workflow debugging

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -348,33 +348,19 @@ This feature is especially useful during development and troubleshooting, as it 
 ## Architecture Diagram
 
 ```mermaid
-flowchart TD
-    A[Flow::start] --> B[run Steps]
-    B --> C[branch Conditions]
-    C --> D[chain Steps]
-    D --> E[execute Payload]
-    E --> F[Final Output]
+sequenceDiagram
+    participant Client
+    participant Flow
+    participant Step
+    participant Logger
 
-    subgraph "Workflow Steps"
-        B1[Validate Data]
-        B2[Hash Password]
-        B3[Create User]
-        B4[Send Welcome Email]
-    end
-
-    subgraph "Conditional Branches"
-        C1[IsVIPUser?]
-        C2[Send VIP Welcome Email]
-    end
-
-    A --> B1
-    B1 --> B2
-    B2 --> B3
-    B3 --> B4
-    B4 --> C1
-    C1 -- Yes --> C2
-    C1 -- No --> D
-    C2 --> D
+    Client->>Flow: debug(logger)
+    Client->>Flow: execute(payload)
+    Flow->>Logger: log("Before step:", payload)
+    Flow->>Step: execute(payload)
+    Step-->>Flow: stepResult
+    Flow->>Logger: log("After step:", stepResult)
+    Flow-->>Client: stepResult
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -309,6 +309,42 @@ $result = Flow::start()->run(
 
 By following these interfaces, every step in your workflow will have a consistent contract, making your code more robust, maintainable, and easier to test.
 
+## Debugging & Logging
+
+The `debug()` method lets you inject a PSR-3 compatible logger (such as the Laravel built-in logger) into your workflow.
+When a logger is set, the Flow class automatically wraps each step with logging calls, which log the payload before and after each step is executed.
+This is invaluable for debugging complex workflows, as it gives you clear insights into how the data transforms throughout the process.
+
+### How it Works
+
+When you call `debug()`, the Flow instance stores the provided logger. Then, in the `execute()` method, if a logger is present, it wraps every step in a closure that:
+
+- Logs a “Before step:” message along with the current payload.
+- Executes the step (whether it’s a class or a closure).
+- Logs an “After step:” message along with the result from the step.
+
+This logging mechanism happens automatically without modifying your individual step logic, so you can focus on business logic and easily troubleshoot the execution flow.
+
+### Example Usage
+
+```php
+use JustSteveKing\Flows\Flow;
+use App\Flows\Steps\HashPassword;
+use Illuminate\Support\Facades\Log;
+
+$result = Flow::start()
+    ->debug(Log::channel('stack'))  // Inject the logger you want to use.
+    ->run(HashPassword::class)
+    ->execute('initial payload');
+```
+
+With the logger enabled, you’ll see log entries like:
+
+- **Before step**: "Before step: App\Flows\Steps\HashPassword" with the current payload.
+- **After step**: "After step: App\Flows\Steps\HashPassword" with the transformed payload.
+
+This feature is especially useful during development and troubleshooting, as it helps you track the data transformations throughout your workflow.
+
 ## Architecture Diagram
 
 ```mermaid

--- a/src/Flow.php
+++ b/src/Flow.php
@@ -8,19 +8,26 @@ use Closure;
 use Illuminate\Support\Facades\Pipeline;
 use JustSteveKing\Flows\Contracts\FlowCondition;
 use JustSteveKing\Flows\Contracts\FlowStep;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
 
 final class Flow
 {
     /**
-     * @param array<int,class-string<FlowStep>|Closure|FlowStep> $steps
+     * Flow constructor.
+     *
+     * @param array<int, class-string<FlowStep>|Closure> $steps
+     * @param LoggerInterface|null $logger
      */
     public function __construct(
-        protected array $steps = [],
+        private array $steps = [],
+        private ?LoggerInterface $logger = null,
     ) {}
 
     /**
+     * Create a new Flow instance.
+     *
      * @return Flow
      */
     public static function start(): Flow
@@ -29,8 +36,23 @@ final class Flow
     }
 
     /**
+     * Set a logger for debugging.
+     *
+     * @param LoggerInterface $logger
+     * @return Flow
+     */
+    public function debug(LoggerInterface $logger): Flow
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * Add a step to the workflow.
+     *
      * @param class-string<FlowStep>|Closure $action
-     * @return $this
+     * @return Flow
      */
     public function run(string|Closure $action): Flow
     {
@@ -40,19 +62,19 @@ final class Flow
     }
 
     /**
+     * Add a conditional branch to the workflow.
+     *
      * @param class-string<FlowCondition> $condition
      * @param callable $callback
-     * @return $this
+     * @return Flow
      */
     public function branch(string $condition, callable $callback): Flow
     {
         $this->steps[] = static function (mixed $payload, Closure $next) use ($condition, $callback) {
             $checker = resolve($condition);
-
             if ($checker($payload)) {
                 $payload = $callback($payload);
             }
-
             return $next($payload);
         };
 
@@ -60,41 +82,32 @@ final class Flow
     }
 
     /**
-     * Add a step that will only run if the condition is met.
+     * Add a step that runs only if the given condition returns true.
      *
      * @param callable $condition A callable that receives the payload and returns a boolean.
      * @param class-string<FlowStep> $action
-     * @return $this
+     * @return Flow
      */
-    public function runIf(callable $condition, string $action): self
+    public function runIf(callable $condition, string $action): Flow
     {
-        $this->steps[] = static function (mixed $payload, Closure $next) use ($condition, $action) {
+        $this->steps[] = function (mixed $payload, Closure $next) use ($condition, $action) {
             if ( ! $condition($payload)) {
                 return $next($payload);
             }
 
-            try {
-                /** @var FlowStep $step */
-                $step = resolve($action);
-            } catch (Throwable $exception) {
-                throw new RuntimeException(
-                    message: sprintf('Failed to resolve action class [%s]: %s', $action, $exception->getMessage()),
-                    previous: $exception,
-                );
-            }
-
-            return $step->handle(
-                payload: $payload,
-                next: $next,
-            );
+            return $this->resolveStep(
+                step: $action,
+            )->handle($payload, $next);
         };
 
         return $this;
     }
 
     /**
+     * Add a chained step to the workflow.
+     *
      * @param class-string<FlowStep> $action
-     * @return $this
+     * @return Flow
      */
     public function chain(string $action): Flow
     {
@@ -103,6 +116,12 @@ final class Flow
         return $this;
     }
 
+    /**
+     * Add error handling to the workflow.
+     *
+     * @param callable $errorHandler
+     * @return Flow
+     */
     public function catch(callable $errorHandler): Flow
     {
         $this->steps[] = static function (mixed $payload, Closure $next) use ($errorHandler) {
@@ -117,15 +136,78 @@ final class Flow
     }
 
     /**
+     * Execute the workflow with the given payload.
+     *
      * @param mixed $payload
      * @return mixed
      */
     public function execute(mixed $payload): mixed
     {
-        return Pipeline::send(
-            passable: $payload,
-        )->through(
-            pipes: $this->steps,
-        )->thenReturn();
+        $steps = $this->steps;
+
+        if (null !== $this->logger) {
+            $logger = $this->logger; // capture logger for closure.
+            $steps = array_map(function (string|Closure $step) use ($logger): Closure {
+                return function ($payload, Closure $next) use ($step, $logger) {
+                    $stepName = is_string($step) ? $step : 'Closure';
+
+                    $this->log(
+                        message: "Before step: {$stepName}",
+                        context: ['payload' => $payload],
+                    );
+
+                    if (is_callable($step)) {
+                        $result = $step($payload, $next);
+                    } else {
+                        $resolved = $this->resolveStep($step);
+                        $result = $resolved->handle($payload, $next);
+                    }
+
+                    $logger->info("After step: {$stepName}", ['result' => $result]);
+                    return $result;
+                };
+            }, $steps);
+        }
+
+        return Pipeline::send($payload)
+            ->through($steps)
+            ->thenReturn();
+    }
+
+    /**
+     * @param class-string<FlowStep> $step
+     * @return FlowStep
+     */
+    private function resolveStep(string $step): FlowStep
+    {
+        try {
+            $step = resolve($step);
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                sprintf(
+                    'Failed to resolve action class [%s]: %s',
+                    $step,
+                    $exception->getMessage(),
+                ),
+                0,
+                $exception,
+            );
+        }
+
+        return $step;
+    }
+
+    private function log(string $message, mixed $context): void
+    {
+        if (null === $this->logger) {
+            throw new RuntimeException(
+                message: 'You need to set a logger before running the flow using the debug method.',
+            );
+        }
+
+        $this->logger->info(
+            message: $message,
+            context: (array) $context,
+        );
     }
 }


### PR DESCRIPTION
This pull request introduces a debugging and logging feature to the `Flow` class, allowing developers to inject a PSR-3 compatible logger to track the execution of workflow steps. It includes updates to the `Flow` class, documentation, and tests.

### Debugging and Logging Feature:

* **README.md**: Added a new section on debugging and logging, explaining how to use the `debug()` method to inject a logger into the workflow, and providing an example usage.

* **src/Flow.php**:
  - Introduced a `LoggerInterface` property to the `Flow` class and updated the constructor to accept an optional logger.
  - Added a `debug` method to set the logger for the `Flow` instance.
  - Modified the `execute` method to log messages before and after each step if a logger is present.

### Codebase Improvements:

* **src/Flow.php**:
  - Refactored the `runIf` method to use a private `resolveStep` method for resolving action classes.
  - Added doc comments to improve code readability and maintainability.

### Tests:

* **tests/FlowTest.php**:
  - Updated tests to expect `RuntimeException` instead of `Exception`.
  - Added a new test to verify that logging is called before and after each step when a logger is injected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled a debug mode that logs execution details before and after each workflow step, enhancing transparency.
- **Documentation**
  - Added a "Debugging & Logging" section that explains how to enable and use the new logging functionality.
- **Tests**
  - Introduced tests to verify that the logging behavior and error handling work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->